### PR TITLE
Support fast goroutine ID access on arm64

### DIFF
--- a/goid_gccgo.go
+++ b/goid_gccgo.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
+//go:build gccgo
 // +build gccgo
 
 package goid

--- a/goid_go1.3.go
+++ b/goid_go1.3.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
+//go:build !go1.4
 // +build !go1.4
 
 package goid

--- a/goid_go1.4.go
+++ b/goid_go1.4.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
+//go:build go1.4 && !go1.5
 // +build go1.4,!go1.5
 
 package goid

--- a/goid_go1.5_amd64.go
+++ b/goid_go1.5_amd64.go
@@ -13,8 +13,10 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
+//go:build (amd64 || amd64p32) && gc && go1.5
 // +build amd64 amd64p32
-// +build gc,go1.5
+// +build gc
+// +build go1.5
 
 package goid
 

--- a/goid_go1.5_amd64.s
+++ b/goid_go1.5_amd64.s
@@ -15,8 +15,10 @@
 
 // Assembly to mimic runtime.getg.
 
+//go:build (amd64 || amd64p32) && gc && go1.5
 // +build amd64 amd64p32
-// +build gc,go1.5
+// +build gc
+// +build go1.5
 
 #include "go_asm.h"
 #include "textflag.h"

--- a/goid_go1.5_arm.go
+++ b/goid_go1.5_arm.go
@@ -13,13 +13,15 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-//go:build arm && gc && go1.5
-// +build arm,gc,go1.5
+//go:build (arm || arm64) && gc && go1.5
+// +build arm arm64
+// +build gc
+// +build go1.5
 
 package goid
 
 // Backdoor access to runtime·getg().
-func getg() *g // in goid_go1.5plus.s
+func getg() *g // in goid_go1.5_arm.s or goid_go1.5_arm64.s
 
 func Get() int64 {
 	return getg().goid

--- a/goid_go1.5_arm.go
+++ b/goid_go1.5_arm.go
@@ -13,8 +13,8 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-// +build arm
-// +build gc,go1.5
+//go:build arm && gc && go1.5
+// +build arm,gc,go1.5
 
 package goid
 

--- a/goid_go1.5_arm.s
+++ b/goid_go1.5_arm.s
@@ -16,8 +16,10 @@
 // Assembly to mimic runtime.getg.
 // This should work on arm64 as well, but it hasn't been tested.
 
+//go:build arm && gc && go1.5
 // +build arm
-// +build gc,go1.5
+// +build gc
+// +build go1.5
 
 #include "textflag.h"
 

--- a/goid_go1.5_arm.s
+++ b/goid_go1.5_arm.s
@@ -14,7 +14,6 @@
 // for names of contributors.
 
 // Assembly to mimic runtime.getg.
-// This should work on arm64 as well, but it hasn't been tested.
 
 //go:build arm && gc && go1.5
 // +build arm

--- a/goid_go1.5_arm64.s
+++ b/goid_go1.5_arm64.s
@@ -1,4 +1,4 @@
-// Copyright 2016 Peter Mattis.
+// Copyright 2021 Peter Mattis.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,12 +13,16 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-//go:build (go1.4 && !go1.5 && !amd64 && !amd64p32 && !arm && !386) || (go1.5 && !amd64 && !amd64p32 && !arm && !arm64)
-// +build go1.4,!go1.5,!amd64,!amd64p32,!arm,!386 go1.5,!amd64,!amd64p32,!arm,!arm64
+// Assembly to mimic runtime.getg.
 
-package goid
+//go:build arm64 && gc && go1.5
+// +build arm64
+// +build gc
+// +build go1.5
 
-// Get returns the id of the current goroutine.
-func Get() int64 {
-	return getSlow()
-}
+#include "textflag.h"
+
+// func getg() *g
+TEXT ·getg(SB),NOSPLIT,$0-8
+	MOVD g, ret+0(FP)
+	RET

--- a/goid_slow.go
+++ b/goid_slow.go
@@ -13,8 +13,8 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-//go:build (go1.4 && !go1.5 && !amd64 && !amd64p32 && !arm && !386) || (go1.5 && !go1.6 && !amd64 && !amd64p32 && !arm) || (go1.6 && !amd64 && !amd64p32 && !arm) || (go1.9 && !amd64 && !amd64p32 && !arm)
-// +build go1.4,!go1.5,!amd64,!amd64p32,!arm,!386 go1.5,!go1.6,!amd64,!amd64p32,!arm go1.6,!amd64,!amd64p32,!arm go1.9,!amd64,!amd64p32,!arm
+//go:build (go1.4 && !go1.5 && !amd64 && !amd64p32 && !arm && !386) || (go1.5 && !amd64 && !amd64p32 && !arm)
+// +build go1.4,!go1.5,!amd64,!amd64p32,!arm,!386 go1.5,!amd64,!amd64p32,!arm
 
 package goid
 

--- a/goid_slow.go
+++ b/goid_slow.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
+//go:build (go1.4 && !go1.5 && !amd64 && !amd64p32 && !arm && !386) || (go1.5 && !go1.6 && !amd64 && !amd64p32 && !arm) || (go1.6 && !amd64 && !amd64p32 && !arm) || (go1.9 && !amd64 && !amd64p32 && !arm)
 // +build go1.4,!go1.5,!amd64,!amd64p32,!arm,!386 go1.5,!go1.6,!amd64,!amd64p32,!arm go1.6,!amd64,!amd64p32,!arm go1.9,!amd64,!amd64p32,!arm
 
 package goid

--- a/runtime_gccgo_go1.8.go
+++ b/runtime_gccgo_go1.8.go
@@ -1,3 +1,4 @@
+//go:build gccgo && go1.8
 // +build gccgo,go1.8
 
 package goid

--- a/runtime_go1.5.go
+++ b/runtime_go1.5.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
+//go:build go1.5 && !go1.6
 // +build go1.5,!go1.6
 
 package goid

--- a/runtime_go1.6.go
+++ b/runtime_go1.6.go
@@ -1,3 +1,4 @@
+//go:build gc && go1.6 && !go1.9
 // +build gc,go1.6,!go1.9
 
 package goid

--- a/runtime_go1.9.go
+++ b/runtime_go1.9.go
@@ -1,3 +1,4 @@
+//go:build gc && go1.9
 // +build gc,go1.9
 
 package goid


### PR DESCRIPTION
This commit updates the library to support fast access to the current goroutine ID on arm64 architectures. I noticed the need for this when running a few benchmarks in cockroachdb's `tracing` package.

Unfortunately, the existing 32-bit ARM assembly does not work with arm64, because it uses a MOV instruction variant with an incorrect width (32-bit vs. 64-bit). Replacing MOVW with MOVD does the trick. See https://pkg.go.dev/cmd/internal/obj/arm64#hdr-Instructions_mnemonics_mapping_rules.

I don't think CI tests on arm64, so here's some confirmation that this all works on my M1 mac:
```
➜ go env
GO111MODULE=""
GOARCH="arm64"
GOBIN=""
GOCACHE="/Users/nathan/Library/Caches/go-build"
GOENV="/Users/nathan/Library/Application Support/go/env"
GOEXE=""
GOEXPERIMENT=""
GOFLAGS=""
GOHOSTARCH="arm64"
GOHOSTOS="darwin"
GOINSECURE=""
GOMODCACHE="/Users/nathan/Go/pkg/mod"
GONOPROXY=""
GONOSUMDB=""
GOOS="darwin"
GOPATH="/Users/nathan/Go"
GOPRIVATE=""
GOPROXY="https://proxy.golang.org,direct"
GOROOT="/Users/nathan/Go/go"
GOSUMDB="sum.golang.org"
GOTMPDIR=""
GOTOOLDIR="/Users/nathan/Go/go/pkg/tool/darwin_arm64"
GOVCS=""
GOVERSION="go1.17.3"
GCCGO="gccgo"
AR="ar"
CC="clang"
CXX="clang++"
CGO_ENABLED="1"
GOMOD="/dev/null"
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -arch arm64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/hn/4tk2rm215ld9k2x8yq7rr78m0000gq/T/go-build3083548140=/tmp/go-build -gno-record-gcc-switches -fno-common"

➜ GO111MODULE=off go test . -count=1 -v
=== RUN   TestGet
--- PASS: TestGet (0.00s)
PASS
ok  	github.com/petermattis/goid	0.099s

➜ GO111MODULE=off go test . -bench=. -benchmem
goos: darwin
goarch: arm64
pkg: github.com/petermattis/goid
BenchmarkGet-10    	550983054	         2.268 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/petermattis/goid	1.583s
```

Here's the impact this change has on performance:
```
➜ GO111MODULE=off benchdiff .
checking out '7abefc4'
building benchmark binaries for '7abefc4' 1/1 -
checking out 'c091d1c'
building benchmark binaries for 'c091d1c' 1/1 |

  pkg=1/1 iter=10/10 petermattis/goid \

name    old time/op    new time/op    delta
Get-10    2.21µs ± 1%    0.00µs ± 4%   -99.91%  (p=0.000 n=9+9)

name    old alloc/op   new alloc/op   delta
Get-10     65.2B ± 2%      0.0B       -100.00%  (p=0.000 n=10+10)

name    old allocs/op  new allocs/op  delta
Get-10      1.60 ±38%      0.00       -100.00%  (p=0.000 n=10+10)
```