### PR TITLE
Update to go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/petermattis/goid
+
+go 1.17


### PR DESCRIPTION
This avoids the need to set the `GO111MODULE=off` env var when running with Go 1.16+.

Diff generated with:
```
➜ go version
go version go1.17.5 darwin/arm64

➜ go mod init
go: creating new go.mod: module github.com/petermattis/goid
go: to add module requirements and sums:
	go mod tidy

➜ go mod tidy

➜ go mod vendor
go: no dependencies to vendor

➜ go test .
ok  	github.com/petermattis/goid	0.699s
```

This is mod file is nice and simple because the project has no external dependencies.