### PR TITLE
Detect failed tests in ARM CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,10 +19,6 @@ jobs:
           - aarch64
           - x64
         go:
-          - '1.5'
-          - '1.6'
-          - '1.7'
-          - '1.8'
           - '1.9'
           - '1.10'
           - '1.11'
@@ -41,6 +37,18 @@ jobs:
           - go: '1.4'
             arch: x64
             race_build: false
+          - go: '1.5'
+            arch: x64
+            race_build: true
+          - go: '1.6'
+            arch: x64
+            race_build: true
+          - go: '1.7'
+            arch: x64
+            race_build: true
+          - go: '1.8'
+            arch: x64
+            race_build: true
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go
@@ -87,5 +95,5 @@ jobs:
           distro: bullseye
           dockerRunArgs: --mount type=bind,source="$(pwd)",target=/checkout,readonly
           run: |
-            find /checkout -name '*.test' -type f -executable -exec '{}' -test.v \;
-            find /checkout -name '*.test' -type f -executable -exec '{}' -test.bench=. -test.benchmem -test.v \;
+            find /checkout -name '*.test' -type f -executable -print0 | \
+              xargs -t -0 -I '{}' sh -c '{} -test.v && {} -test.bench=. -test.benchmem -test.v'


### PR DESCRIPTION
This commit fixes ARM testing so that it reports a failure when unit tests fail. This was broken because `find -exec` was not doing what was expected. To fix this, we now use `find | xargs`.

See https://apple.stackexchange.com/questions/49042/how-do-i-make-find-fail-if-exec-fails. `find -exec` returns a 0 exit code unless an error occurred while traversing the directories; the return status of executed commands does not matter.

cc. @tamird 