### PR TITLE
Add CI coverage through go1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,6 +33,9 @@ jobs:
           - '1.15'
           - '1.16'
           - '1.17'
+          - '1.18'
+          - '1.19'
+          - '1.20'
         # Race detector binaries crash with:
         #
         # FATAL: ThreadSanitizer: unsupported VMA range


### PR DESCRIPTION
Symbolic versions {,old}stable are not added because of the need to download binary blobs for race builds on arm64 which uses the literal go version string.

Fixes #29.