### PR TITLE
Add CI coverage for gccgo

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,11 +54,30 @@ jobs:
           #
           # Cross-compilation became possible in go1.5 with the removal of C
           # code from the compiler. See https://go.dev/doc/go1.5#c.
+          #
+          # Race builds aren't supported in gccgo.
+          #
+          # Cross-compilation isn't supported in gccgo.
           - arch: x64
             go: '1.3'
             x64_race_broken: true
           - arch: x64
             go: '1.4'
+            x64_race_broken: true
+          - arch: x64
+            go: gccgo-9
+            x64_race_broken: true
+          - arch: x64
+            go: gccgo-10
+            x64_race_broken: true
+          - arch: x64
+            go: gccgo-11
+            x64_race_broken: true
+          - arch: x64
+            go: gccgo-12
+            x64_race_broken: true
+          - arch: x64
+            go: gccgo-13
             x64_race_broken: true
           # Go binaries built with Go 1.8 and below are incompatible with QEMU
           # user-level emulation. See
@@ -125,9 +144,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
+        if: ${{ !startsWith(matrix.go, 'gccgo-') }}
         uses: actions/setup-go@v4.0.1
         with:
           go-version: ${{ matrix.go }}
+      - name: Set up gccgo
+        if: ${{ startsWith(matrix.go, 'gccgo-') }}
+        run: |
+          sudo apt update && \
+          sudo apt install -y ${{ matrix.go }} && \
+          echo ${{ matrix.go }} | sed 's/^gcc//' | xargs -I % ln -s /usr/bin/% /usr/local/bin/go && \
+          go version
       - name: 'Build with ${{ matrix.go }}'
         if: ${{ matrix.arch == 'x64' }}
         run: go build -v ./...
@@ -137,13 +164,13 @@ jobs:
           GOARCH: 386
         run: go build -v ./...
       - name: 'Check that Get is inlined with ${{ matrix.go }}'
-        if: ${{ matrix.arch == 'x64' }}
+        if: ${{ !startsWith(matrix.go, 'gccgo-') && matrix.arch == 'x64' }}
         run: |
           if echo -e '${{ matrix.go }}\n1.12' | sort -V | head -n1 | xargs test 1.12 = ; then
             go build -gcflags='-m' 2>&1 | grep 'can inline Get$' > /dev/null
           fi
       - name: 'Check that Get is inlined with ${{ matrix.go }}'
-        if: ${{ matrix.arch == '386' }}
+        if: ${{ !startsWith(matrix.go, 'gccgo-') && matrix.arch == '386' }}
         env:
           GOARCH: 386
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # goid ![Build Status](https://github.com/petermattis/goid/actions/workflows/go.yml/badge.svg)
 
 Programatically retrieve the current goroutine's ID. See [the CI
-configuration](.github/workflows/go.yml) for supported Go versions. In
-addition, gccgo 7.2.1 (Go 1.8.3) is supported.
+configuration](.github/workflows/go.yml) for supported Go versions.

--- a/runtime_gccgo_go1.8.go
+++ b/runtime_gccgo_go1.8.go
@@ -3,7 +3,7 @@
 
 package goid
 
-// https://github.com/gcc-mirror/gcc/blob/gcc-7-branch/libgo/go/runtime/runtime2.go#L329-L422
+// https://github.com/gcc-mirror/gcc/blob/releases/gcc-7/libgo/go/runtime/runtime2.go#L329-L354
 
 type g struct {
 	_panic       uintptr


### PR DESCRIPTION
apt packages for earlier version don't seem to be available.
