### PR TITLE
Support fast goroutine ID access on s390x 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,7 @@ jobs:
           - armv6
           - armv7
           - aarch64
+          - s390x
           - 386
           - x64
         go:
@@ -41,6 +42,12 @@ jobs:
           - '1.20'
           - '1.21'
           - '1.22'
+        exclude:
+          # Support for s390x was added in Go1.7. See https://go.dev/doc/go1.7#ports.
+          - arch: s390x
+            go: '1.5'
+          - arch: s390x
+            go: '1.6'
         # Race detector binaries crash with:
         #
         # FATAL: ThreadSanitizer: unsupported VMA range
@@ -124,6 +131,12 @@ jobs:
           - arch: aarch64
             go: '1.8'
             qemu_emulation_broken: true
+          - arch: s390x
+            go: '1.7'
+            qemu_emulation_broken: true
+          - arch: s390x
+            go: '1.8'
+            qemu_emulation_broken: true
           # Race detector support on linux/arm64 was added in go1.12. See
           # https://go.dev/doc/go1.12.
           - arch: aarch64
@@ -181,6 +194,9 @@ jobs:
               ;;
             aarch64)
               echo GOARCH=arm64 >> "$GITHUB_ENV"
+              ;;
+            s390x)
+              echo GOARCH=s390x >> "$GITHUB_ENV"
               ;;
             386)
               echo GOARCH=386 >> "$GITHUB_ENV"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,6 +55,13 @@ jobs:
         # See https://github.com/golang/go/issues/29948.
         arm64_unsupported_vma_range:
           - true
+        # Race detector binaries crash with:
+        #
+        # ==17==ERROR: ThreadSanitizer failed to allocate 0x7f0000 (8323072) bytes at address 9000001a0000 (errno: 12)
+        #
+        # See https://github.com/golang/go/issues/67881.
+        s390x_thread_sanitizer_failed_to_allocate:
+          - true
         include:
           # Race builds are pretty much busted on Go 1.4 and below on systems
           # with newer C compilers. A number of fixes were backported to
@@ -160,6 +167,44 @@ jobs:
           - arch: aarch64
             go: '1.11'
             arm64_race_unsupported: true
+          # Race detector support on linux/s390x was added in go1.19. See
+          # https://go.dev/doc/go1.19.
+          - arch: s390x
+            go: '1.7'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.8'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.9'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.10'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.11'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.12'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.13'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.14'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.15'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.16'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.17'
+            s390x_race_unsupported: true
+          - arch: s390x
+            go: '1.18'
+            s390x_race_unsupported: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -231,10 +276,9 @@ jobs:
         if: ${{ matrix.arch == 'x64' && !matrix.x64_race_broken }}
       - run: go test -c ./...
         if: ${{ matrix.arch != 'x64' && matrix.arch != '386'}}
-      - name: 'BuildTestRace with ${{ matrix.go }} for aarch64'
-        if: ${{ matrix.arch == 'aarch64' && !matrix.arm64_race_unsupported }}
+      - name: 'BuildTestRace with ${{ matrix.go }} for ${{ matrix.arch }}'
+        if: ${{ matrix.arch == 'aarch64' && !matrix.arm64_race_unsupported || matrix.arch == 's390x' && !matrix.s390x_race_unsupported }}
         env:
-          GOARCH: arm64
           CGO_ENABLED: 1
         shell: bash
         run: |
@@ -242,15 +286,15 @@ jobs:
 
           # Non-host *.syso files are missing from the Go toolchains provided
           # by setup-go. See https://github.com/actions/setup-go/issues/181.
-          curl --location --output "$(go env GOROOT)"/src/runtime/race/race_linux_arm64.syso \
-            https://github.com/golang/go/raw/release-branch.go${{ matrix.go }}/src/runtime/race/race_linux_arm64.syso
+          curl --location --output "$(go env GOROOT)"/src/runtime/race/race_linux_"$GOARCH".syso \
+            https://github.com/golang/go/raw/release-branch.go${{ matrix.go }}/src/runtime/race/race_linux_"$GOARCH".syso
 
           sudo apt update
-          sudo apt install -y gcc-aarch64-linux-gnu
+          sudo apt install -y gcc-${{ matrix.arch }}-linux-gnu
 
-          CC=aarch64-linux-gnu-gcc CC_FOR_TARGET=gcc-aarch64-linux-gnu go test -c -race -o goid.race.test ./...
-      - name: 'DeleteTestRace with $$ {{ matrix.go}} for aarch64'
-        if: ${{ matrix.arch == 'aarch64' && !matrix.arm64_race_unsupported && matrix.arm64_unsupported_vma_range }}
+          CC=${{ matrix.arch }}-linux-gnu-gcc CC_FOR_TARGET=gcc-${{ matrix.arch }}-linux-gnu go test -c -race -o goid.race.test ./...
+      - name: 'DeleteTestRace with $$ {{ matrix.go}} for ${{ matrix.arch }}'
+        if: ${{ matrix.arch == 'aarch64' && !matrix.arm64_race_unsupported && matrix.arm64_unsupported_vma_range || matrix.arch == 's390x' && !matrix.s390x_race_unsupported && matrix.s390x_thread_sanitizer_failed_to_allocate }}
         run: rm goid.race.test
       - name: 'Test and Bench with ${{ matrix.go }} on ${{ matrix.arch }}'
         if: ${{ matrix.arch != '386' && matrix.arch != 'x64' && !matrix.qemu_emulation_broken }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -293,7 +293,7 @@ jobs:
           sudo apt install -y gcc-${{ matrix.arch }}-linux-gnu
 
           CC=${{ matrix.arch }}-linux-gnu-gcc CC_FOR_TARGET=gcc-${{ matrix.arch }}-linux-gnu go test -c -race -o goid.race.test ./...
-      - name: 'DeleteTestRace with $$ {{ matrix.go}} for ${{ matrix.arch }}'
+      - name: 'DeleteTestRace with $${{ matrix.go }} for ${{ matrix.arch }}'
         if: ${{ matrix.arch == 'aarch64' && !matrix.arm64_race_unsupported && matrix.arm64_unsupported_vma_range || matrix.arch == 's390x' && !matrix.s390x_race_unsupported && matrix.s390x_thread_sanitizer_failed_to_allocate }}
         run: rm goid.race.test
       - name: 'Test and Bench with ${{ matrix.go }} on ${{ matrix.arch }}'

--- a/goid_go1.5.go
+++ b/goid_go1.5.go
@@ -13,8 +13,8 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-//go:build (386 || amd64 || amd64p32 || arm || arm64) && gc && go1.5
-// +build 386 amd64 amd64p32 arm arm64
+//go:build (386 || amd64 || amd64p32 || arm || arm64 || s390x) && gc && go1.5
+// +build 386 amd64 amd64p32 arm arm64 s390x
 // +build gc
 // +build go1.5
 

--- a/goid_go1.5.s
+++ b/goid_go1.5.s
@@ -15,8 +15,8 @@
 
 // Assembly to mimic runtime.getg.
 
-//go:build (386 || amd64 || amd64p32 || arm || arm64) && gc && go1.5
-// +build 386 amd64 amd64p32 arm arm64
+//go:build (386 || amd64 || amd64p32 || arm || arm64 || s390x) && gc && go1.5
+// +build 386 amd64 amd64p32 arm arm64 s390x
 // +build gc
 // +build go1.5
 
@@ -36,6 +36,9 @@ TEXT ·getg(SB),NOSPLIT,$0-8
 	MOVW g, ret+0(FP)
 #endif
 #ifdef GOARCH_arm64
+	MOVD g, ret+0(FP)
+#endif
+#ifdef GOARCH_s390x
 	MOVD g, ret+0(FP)
 #endif
 	RET

--- a/goid_slow.go
+++ b/goid_slow.go
@@ -13,8 +13,8 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-//go:build (go1.4 && !go1.5 && !amd64 && !amd64p32 && !arm && !386) || (go1.5 && !386 && !amd64 && !amd64p32 && !arm && !arm64)
-// +build go1.4,!go1.5,!amd64,!amd64p32,!arm,!386 go1.5,!386,!amd64,!amd64p32,!arm,!arm64
+//go:build (go1.4 && !go1.5 && !amd64 && !amd64p32 && !arm && !386) || (go1.5 && !386 && !amd64 && !amd64p32 && !arm && !arm64 && !s390x)
+// +build go1.4,!go1.5,!amd64,!amd64p32,!arm,!386 go1.5,!386,!amd64,!amd64p32,!arm,!arm64,!s390x
 
 package goid
 


### PR DESCRIPTION
This commit updates the library to support fast access to the current goroutine ID on s390x architecture. It required when running the cockroachdb benchmarks.

```
without patch:
./goid.test -test.v -test.run=^$ -test.bench=. -test.benchmem -test.count=2 | tee old.txt
goos: linux
goarch: s390x
pkg: github.com/petermattis/goid
BenchmarkGet
BenchmarkGet-128     	  201444	      5804 ns/op	      64 B/op	       1 allocs/op
BenchmarkGet-128     	  205909	      5950 ns/op	      64 B/op	       1 allocs/op

with patch:
./goid.test -test.v -test.run=^$ -test.bench=. -test.benchmem -test.count=2 | tee new.txt
goos: linux
goarch: s390x
pkg: github.com/petermattis/goid
BenchmarkGet
BenchmarkGet-128     	622927438	         1.907 ns/op	       0 B/op	       0 allocs/op
BenchmarkGet-128     	596055510	         1.966 ns/op	       0 B/op	       0 allocs/op

benchstat old.txt new.txt
goos: linux
goarch: s390x
pkg: github.com/petermattis/goid
        │    old.txt     │              new.txt               │
        │     sec/op     │   sec/op     vs base               │
Get-128   5917.000n ± 2%   1.935n ± 7%  -99.97% (p=0.000 n=8)
```
Fixes #43