### PR TITLE
ci: add Go support grid

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,6 +78,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      # TODO(https://github.com/actions/setup-go/issues/756): Remove this step
+      # and the cache input below when upstream stops warning about missing
+      # cache paths for Go versions that predate caching.
+      - name: Configure setup-go
+        id: configure_setup_go
+        if: ${{ !startsWith(matrix.go, 'gccgo-') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          IFS=. read -r major minor _ <<< "${{ matrix.go }}"
+          cache=true
+          if (( major == 1 && minor < 10 )); then
+            cache=false
+          fi
+          echo "cache=$cache" >> "$GITHUB_OUTPUT"
       - name: Set up Go
         id: setup-go
         if: ${{ !startsWith(matrix.go, 'gccgo-') }}
@@ -85,6 +101,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
+          cache: ${{ steps.configure_setup_go.outputs.cache }}
       - name: Set up gccgo
         if: ${{ startsWith(matrix.go, 'gccgo-') }}
         shell: bash

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: build (${{ matrix.go }}, ${{ matrix.arch }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -20,7 +21,8 @@ jobs:
           # Cross-compilation became possible in go1.5 with the removal of C
           # code from the compiler. See https://go.dev/doc/go1.5#c.
           #
-          # Cross-compilation isn't supported in gccgo.
+          # gccgo cross-compilation requires a target-specific GCC toolchain
+          # rather than GOARCH, so only native x64 builds are included here.
           - arch: x64
             go: '1.3'
           - arch: x64
@@ -271,3 +273,161 @@ jobs:
 
             find /checkout -name '*.test' -type f -executable -print0 | \
               xargs -t -0 -I '{}' sh -c '{} -test.v && {} -test.bench=. -test.benchmem -test.v'
+
+  report:
+    name: build status
+    if: ${{ always() }}
+    needs: build
+    permissions:
+      actions: read
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+                filter: 'latest',
+                per_page: 100,
+              },
+            );
+
+            const builds = new Map();
+            const architectureSet = new Set();
+            for (const job of jobs) {
+              const match = /^build \(([^,]+), ([^)]+)\)$/.exec(job.name);
+              if (!match) {
+                continue;
+              }
+
+              const [, version, architecture] = match;
+              if (!builds.has(version)) {
+                builds.set(version, new Map());
+              }
+              builds.get(version).set(architecture, job);
+              architectureSet.add(architecture);
+            }
+            if (builds.size === 0) {
+              throw new Error('No matrix build jobs found');
+            }
+
+            const architectures = [...architectureSet].sort();
+            const versions = [...builds.keys()].sort((a, b) => {
+              const aGccgo = a.startsWith('gccgo-');
+              const bGccgo = b.startsWith('gccgo-');
+              if (aGccgo !== bGccgo) {
+                return aGccgo ? 1 : -1;
+              }
+
+              const aParts = a.replace('gccgo-', '').split('.').map(Number);
+              const bParts = b.replace('gccgo-', '').split('.').map(Number);
+              return bParts[0] - aParts[0] || (bParts[1] || 0) - (aParts[1] || 0);
+            });
+
+            const symbols = {
+              action_required: '⚠️',
+              cancelled: '⏹️',
+              failure: '❌',
+              in_progress: '⏳',
+              neutral: '➖',
+              queued: '⏳',
+              skipped: '⏭️',
+              stale: '➖',
+              startup_failure: '❌',
+              success: '✅',
+              timed_out: '⏱️',
+              waiting: '⏳',
+            };
+            const summary = [
+              '## Build status',
+              '',
+              `Results for [${context.sha.slice(0, 7)}](${context.payload.repository.html_url}/commit/${context.sha}).`,
+              '',
+              `| Go | ${architectures.join(' | ')} |`,
+              `| --- | ${architectures.map(() => '---').join(' | ')} |`,
+            ];
+            const readme = summary.slice(4);
+
+            for (const version of versions) {
+              const summaryCells = [];
+              const readmeCells = [];
+              for (const architecture of architectures) {
+                const job = builds.get(version).get(architecture);
+                if (!job) {
+                  summaryCells.push('—');
+                  readmeCells.push('—');
+                  continue;
+                }
+
+                const conclusion = job.conclusion || job.status;
+                const symbol = symbols[conclusion] || '❔';
+                summaryCells.push(`[${symbol}](${job.html_url} "${conclusion}")`);
+                readmeCells.push(
+                  conclusion === 'success'
+                    ? symbol
+                    : `[${symbol}](${job.html_url} "${conclusion}")`,
+                );
+              }
+              summary.push(`| ${version} | ${summaryCells.join(' | ')} |`);
+              readme.push(`| ${version} | ${readmeCells.join(' | ')} |`);
+            }
+
+            const legend = '✅ success · ❌ failure · ⏹️ cancelled · ⏭️ skipped · — not in matrix';
+            summary.push('', legend);
+            readme.push('', legend);
+            await core.summary.addRaw(summary.join('\n')).write();
+
+            const branch = context.payload.repository.default_branch;
+            if (context.eventName === 'pull_request' || context.ref !== `refs/heads/${branch}`) {
+              return;
+            }
+
+            const { data: branchData } = await github.rest.repos.getBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch,
+            });
+            if (branchData.commit.sha !== context.sha) {
+              core.notice('Skipping README update because the workflow commit is no longer current.');
+              return;
+            }
+
+            const { data: file } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'README.md',
+              ref: branch,
+            });
+            if (Array.isArray(file) || file.type !== 'file' || !file.content) {
+              throw new Error('README.md is not a file');
+            }
+
+            const contents = Buffer.from(file.content, 'base64').toString();
+            const start = '<!-- build-status:start -->';
+            const end = '<!-- build-status:end -->';
+            const startIndex = contents.indexOf(start);
+            const endIndex = contents.indexOf(end, startIndex);
+            if (startIndex === -1 || endIndex === -1) {
+              throw new Error('README.md build status markers are missing');
+            }
+
+            const block = `${start}\n${readme.join('\n')}\n${end}`;
+            const updated = contents.slice(0, startIndex) + block + contents.slice(endIndex + end.length);
+            if (updated === contents) {
+              return;
+            }
+
+            await github.rest.repos.createOrUpdateFileContents({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'README.md',
+              branch,
+              message: 'ci: update build status grid',
+              content: Buffer.from(updated).toString('base64'),
+              sha: file.sha,
+            });

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# goid ![Build Status](https://github.com/petermattis/goid/actions/workflows/go.yml/badge.svg)
+# goid [![Build Status](https://github.com/petermattis/goid/actions/workflows/go.yml/badge.svg)](https://github.com/petermattis/goid/actions/workflows/go.yml)
 
 Programatically retrieve the current goroutine's ID. See [the CI
-configuration](.github/workflows/go.yml) for supported Go versions.
+configuration](.github/workflows/go.yml) for supported Go versions and
+architectures. The grid below shows the latest build status from the default
+branch.
+
+## Build status
+
+<!-- build-status:start -->
+<!-- build-status:end -->


### PR DESCRIPTION
Add a github actions job that updates a table in the README.

Anything is possible with infinite tokens.

Closes #68.
