### PR TITLE
ci: coalesce gccgo builds

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ on:
     - cron: 00 4 * * *
 
 jobs:
-  build:
+  gc:
     name: build (${{ matrix.go }}, ${{ matrix.arch }})
     runs-on: ubuntu-latest
     strategy:
@@ -20,25 +20,10 @@ jobs:
         include:
           # Cross-compilation became possible in go1.5 with the removal of C
           # code from the compiler. See https://go.dev/doc/go1.5#c.
-          #
-          # gccgo cross-compilation requires a target-specific GCC toolchain
-          # rather than GOARCH, so only native x64 builds are included here.
           - arch: x64
             go: '1.3'
           - arch: x64
             go: '1.4'
-          - arch: x64
-            go: gccgo-9
-          - arch: x64
-            go: gccgo-10
-          - arch: x64
-            go: gccgo-11
-          - arch: x64
-            go: gccgo-12
-          - arch: x64
-            go: gccgo-13
-          - arch: x64
-            go: gccgo-14
         arch:
           - armv6
           - armv7
@@ -83,7 +68,6 @@ jobs:
       # cache paths for Go versions that predate caching.
       - name: Configure setup-go
         id: configure_setup_go
-        if: ${{ !startsWith(matrix.go, 'gccgo-') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -96,23 +80,11 @@ jobs:
           echo "cache=$cache" >> "$GITHUB_OUTPUT"
       - name: Set up Go
         id: setup-go
-        if: ${{ !startsWith(matrix.go, 'gccgo-') }}
         uses: actions/setup-go@v6.5.0
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
           cache: ${{ steps.configure_setup_go.outputs.cache }}
-      - name: Set up gccgo
-        if: ${{ startsWith(matrix.go, 'gccgo-') }}
-        shell: bash
-        run: |
-          set -euxo pipefail
-
-          sudo apt update
-          sudo apt install -y ${{ matrix.go }}
-          echo ${{ matrix.go }} | sed 's/^gcc//' | xargs -I % ln -s /usr/bin/% /usr/local/bin/go
-
-          go version
       - name: Configure environment
         id: configure_environment
         shell: bash
@@ -195,7 +167,6 @@ jobs:
           echo "S390X_THREAD_SANITIZER_FAILED_TO_ALLOCATE=1" >> "$GITHUB_OUTPUT"
       - name: Check that Get is inlined
         if: |
-          !startsWith(matrix.go, 'gccgo-') &&
           steps.configure_environment.outputs.BETTER_INLINING_AVAILABLE
         shell: bash
         run: |
@@ -211,13 +182,10 @@ jobs:
           go test -c -o goid.test ./...
       - name: go build & go test -c (race)
         # Race builds aren't supported on linux/386.
-        #
-        # Race builds aren't supported in gccgo.
         id: build_goid_race_test
         if: |
           !cancelled() &&
           matrix.arch == 'x64' &&
-          !startsWith(matrix.go, 'gccgo-') &&
           !steps.configure_environment.outputs.RACE_BUILDS_BROKEN
         shell: bash
         run: |
@@ -302,10 +270,59 @@ jobs:
           find . -name '*.test' -type f -executable -print0 | \
             xargs -t -0 -I '{}' sh -c '{} -test.v && {} -test.bench=. -test.benchmem -test.v'
 
+  gccgo:
+    name: build (${{ matrix.versions }}, x64)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # gccgo cross-compilation requires a target-specific GCC toolchain
+        # rather than GOARCH, so only native x64 builds are included here.
+        versions:
+          - gccgo-9 gccgo-10 gccgo-11 gccgo-12 gccgo-13 gccgo-14
+    outputs:
+      results: ${{ steps.run.outputs.results }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up gccgo
+        shell: bash
+        run: |
+          set -euxo pipefail
+
+          sudo apt update
+          sudo apt install --yes -- ${{ matrix.versions }}
+
+      # Race builds aren't supported in gccgo.
+      - name: Build and run tests
+        id: run
+        shell: bash
+        run: |
+          set -euxo pipefail
+
+          # Keep running after a failure so the report retains each version's result.
+          status=0
+          results=
+          for compiler in ${{ matrix.versions }}; do
+            if ln --symbolic --force -- "/usr/bin/${compiler#gcc}" /usr/local/bin/go &&
+              go version &&
+              go build -v ./... &&
+              go test -c -o goid.test ./... &&
+              ./goid.test -test.v &&
+              ./goid.test -test.bench=. -test.benchmem -test.v
+            then
+              result=success
+            else
+              result=failure
+              status=1
+            fi
+            results+="$compiler=$result "
+          done
+          echo "results=${results% }" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
   report:
     name: build status
     if: ${{ always() }}
-    needs: build
+    needs: [gc, gccgo]
     permissions:
       actions: read
       contents: write
@@ -325,6 +342,13 @@ jobs:
               },
             );
 
+            // The coalesced gccgo job still reports each compiler separately.
+            const groupedResults = new Map(
+              '${{ needs.gccgo.outputs.results }}'
+                .split(' ')
+                .filter(Boolean)
+                .map(result => result.split('=', 2)),
+            );
             const builds = new Map();
             const architectureSet = new Set();
             for (const job of jobs) {
@@ -333,11 +357,17 @@ jobs:
                 continue;
               }
 
-              const [, version, architecture] = match;
-              if (!builds.has(version)) {
-                builds.set(version, new Map());
+              const [, versionList, architecture] = match;
+              for (const version of versionList.split(' ')) {
+                if (!builds.has(version)) {
+                  builds.set(version, new Map());
+                }
+                const conclusion = groupedResults.get(version);
+                builds.get(version).set(
+                  architecture,
+                  conclusion ? {...job, conclusion} : job,
+                );
               }
-              builds.get(version).set(architecture, job);
               architectureSet.add(architecture);
             }
             if (builds.size === 0) {


### PR DESCRIPTION
gccgo jobs spend most of their time starting runners and running apt, while the builds and tests themselves are tiny. Run all supported gccgo versions in one job so checkout, apt update, and package installation happen once.

The job emits each compiler's conclusion before returning its aggregate status. The report uses those per-version conclusions, falling back to the job conclusion if setup fails before any result is available.